### PR TITLE
Escaping backslash

### DIFF
--- a/autoload/lsp_ultisnips.vim
+++ b/autoload/lsp_ultisnips.vim
@@ -1,5 +1,6 @@
 function! s:escape_string(str) abort
-    let l:ret = substitute(a:str, '\%x00', '\\n', 'g')
+    let l:ret = substitute(a:str, '\\', '\\\\', 'g')
+    let l:ret = substitute(l:ret, '\%x00', '\\n', 'g')
     let l:ret = substitute(l:ret, '"', '\\"', 'g')
     return l:ret
 endfunction


### PR DESCRIPTION
Backslashes have to be escaped, otherwise, it leads to unpredictable behavior.
Here is an example:
without escaping backslash the following Latex snippet
```
\begin{} 

\end{}
```
will be inserted as
```
\begin{}

 ^[nd{}
```
the `\e` in `\end{}` is treated as the "Escape" character.
after substituting all instances of '\\' with '\\\\', the problem is fixed.